### PR TITLE
Fixes a bug where Touchables inside GestureView won't work.

### DIFF
--- a/GestureView.js
+++ b/GestureView.js
@@ -37,10 +37,13 @@ export default class GestureView extends Component {
   }
 
   componentWillMount () {
+    const touchThreshold = 20;
     this._panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: (evt, gestureState) =>
-        gestureState.dx !== 0 || gestureState.dy !== 0,
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (evt, gestureState) =>{
+        const {dx, dy} = gestureState;
+        return (Math.abs(dx) > touchThreshold) || (Math.abs(dy) > touchThreshold);
+      },
       onPanResponderRelease: (...args) => this.handleSwipe(...args)
     })
   }


### PR DESCRIPTION
On Android devices, when having a Touchable component inside GestureView component, won't respond to touches because of the threshold applied.
With this fix, GestureView will detect when user is just pressing a button or is swiping the view.

For example:
```
<GestureView onSwipeDown={()=>{this.myFunc()}}>
    <View>
        <TouchableOpacity onPress={()=>{this.onPress()}}>
            <Icon name="pause" size={30}/>
        </TouchableOpacity>
     </View>
</GestureView>
```